### PR TITLE
fix: the file keystore.properties not found.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@
 local.properties
 /buildSrc/build
 /buildSrc/.gradle
-keystore.properties
+#keystore.properties
 keystore.jks

--- a/keystore.properties
+++ b/keystore.properties
@@ -1,0 +1,11 @@
+#Debug
+DEBUG_STORE_FILE=debug-keystore.jks
+DEBUG_STORE_PASSWORD=123456
+DEBUG_KEY_ALIAS=debug-keystore
+DEBUG_KEY_PASSWORD=123456
+
+#Release
+RELEASE_STORE_FILE=../keystore.jks
+RELEASE_STORE_PASSWORD=store_password
+RELEASE_KEY_ALIAS=key_alias
+RELEASE_KEY_PASSWORD=key_password


### PR DESCRIPTION
- this file just have dummy data not the real keys, so to run the release build please use your keystore and config this file respectively.